### PR TITLE
Add check state for MacOS version

### DIFF
--- a/macOS (App)/AppDelegate.swift
+++ b/macOS (App)/AppDelegate.swift
@@ -6,12 +6,30 @@
 //
 
 import Cocoa
+import SafariServices
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Override point for customization after application launch.
+        
+        let manager = SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: "safari.Wallet.Extension") { state, error in
+            guard let state = state else {
+                guard state == nil else {
+                    print("Error fetching extension state: \(error!.localizedDescription)")
+                    return
+                }
+                print("Unknown error fetching extension state")
+                return
+            }
+            if state.isEnabled == true {
+                print("extension is enabled")
+            } else {
+                print("extension is disabled")
+            }
+        }
+        
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {


### PR DESCRIPTION
Quick and dirty check on MacOS if the extension is enabled by the user.

The used classes are not available on iOS, we'll need a different approach for iOS 