### PR TITLE
Bug fix - task modifer on nested SwiftUI EmptyView doesn't get invoked

### DIFF
--- a/Shared (App)/ContentView.swift
+++ b/Shared (App)/ContentView.swift
@@ -34,17 +34,13 @@ struct ContentView: View {
             }
             .sheet(isPresented: $isOnBoardingPresented) { OnboardingView() }
 //            .fullScreenCover(isPresented: $isOnBoardingPresented, content: OnboardingView.init)
-            
-            EmptyView()
-                .padding()
-                .task {
-                    do {
-                        print("Hello")
-                        try await createTestWallet()
-                    } catch {
-                        print("error: \(error)")
-                    }
-                }
+        }.task {
+           do {
+              print("Hello")
+              try await createTestWallet()
+           } catch {
+              print("error: \(error)")
+           }
         }
     }
 }


### PR DESCRIPTION
It seems like using a task modifier on a nested view doesn't work. Not sure what exactly the reason is but moving the logic to a `task` modifier on the VStack solves the problem