### PR TITLE
Add Web3.swift package and fetch an address's balance

### DIFF
--- a/Shared (App)/TransactionsTab/TransactionsView.swift
+++ b/Shared (App)/TransactionsTab/TransactionsView.swift
@@ -6,13 +6,45 @@
 //
 
 import SwiftUI
+import web3
 
 struct TransactionsView: View {
-    var body: some View {
-       Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/).task {
-          print("Hello Transaction")
-       }
-    }
+   
+   private enum Constants {
+      static let clientUrl: String = "Your_AlchemyApi_OR_Infura_URL"
+      static let ethAccountAddress: String? = nil
+   }
+   
+   @State private var displayText: String = "Loading balance"
+   
+   let ethClient: EthereumClient
+   
+   init() {
+      guard let clientUrl = URL(string: Constants.clientUrl) else { fatalError("You need to set a valid url") }
+      self.ethClient = EthereumClient(url: clientUrl)
+   }
+   
+   var body: some View {
+      Text(displayText).task {
+         self.fetchAccountBalance()
+      }
+   }
+   
+   func fetchAccountBalance() {
+      guard let address = Constants.ethAccountAddress else {
+         self.displayText = "Make sure to set an account address"
+         return
+      }
+      ethClient.eth_getBalance(address: EthereumAddress(address),
+                                block: EthereumBlock(rawValue: "latest")) { error, value in
+         guard let value = value else {
+            self.displayText = "There was an error loading your balance \(String(describing: error))"
+            if let error = error { print(error) }
+            return
+         }
+         self.displayText = "Balance: \(value) Gwei for account \(address)"
+      }
+   }
 }
 
 struct TransactionsView_Previews: PreviewProvider {

--- a/Wallet.xcodeproj/project.pbxproj
+++ b/Wallet.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		0A0E1EE8270687AE00061EA6 /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = 0A0E1E97270687AE00061EA6 /* popup.js */; };
 		275C299427117F7D00DA2773 /* injections in Resources */ = {isa = PBXBuildFile; fileRef = 275C299327117F7D00DA2773 /* injections */; };
 		275C299527117F7D00DA2773 /* injections in Resources */ = {isa = PBXBuildFile; fileRef = 275C299327117F7D00DA2773 /* injections */; };
+		4A23A620271A0D1E0076BBD3 /* web3.swift in Frameworks */ = {isa = PBXBuildFile; productRef = 4A23A61F271A0D1E0076BBD3 /* web3.swift */; };
 		F8321B5927169A1D00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
 		F8321B5A27176EBE00F12938 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5827169A1D00F12938 /* OnboardingView.swift */; };
 		F8321B5C27176ED600F12938 /* ShowMnemonicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321B5B27176ED600F12938 /* ShowMnemonicView.swift */; };
@@ -239,6 +240,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A23A620271A0D1E0076BBD3 /* web3.swift in Frameworks */,
 				F8ABEEE727125002007F7D11 /* HDWalletKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -540,6 +542,7 @@
 			name = "Wallet (iOS)";
 			packageProductDependencies = (
 				F8ABEEE627125002007F7D11 /* HDWalletKit */,
+				4A23A61F271A0D1E0076BBD3 /* web3.swift */,
 			);
 			productName = "Wallet (iOS)";
 			productReference = 0A0E1E9C270687AE00061EA6 /* Wallet.app */;
@@ -664,6 +667,7 @@
 			mainGroup = 0A0E1E7F270687AA00061EA6;
 			packageReferences = (
 				F8ABEEE527125002007F7D11 /* XCRemoteSwiftPackageReference "HDWallet" */,
+				4A23A61E271A0D1E0076BBD3 /* XCRemoteSwiftPackageReference "web3" */,
 			);
 			productRefGroup = 0A0E1E9D270687AE00061EA6 /* Products */;
 			projectDirPath = "";
@@ -1402,6 +1406,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4A23A61E271A0D1E0076BBD3 /* XCRemoteSwiftPackageReference "web3" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tvongerlach/web3.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.8.1;
+			};
+		};
 		F8ABEEE527125002007F7D11 /* XCRemoteSwiftPackageReference "HDWallet" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ronaldmannak/HDWallet";
@@ -1413,6 +1425,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4A23A61F271A0D1E0076BBD3 /* web3.swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A23A61E271A0D1E0076BBD3 /* XCRemoteSwiftPackageReference "web3" */;
+			productName = web3.swift;
+		};
 		F8ABEEE627125002007F7D11 /* HDWalletKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8ABEEE527125002007F7D11 /* XCRemoteSwiftPackageReference "HDWallet" */;

--- a/Wallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Wallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "BigInt",
+        "repositoryURL": "https://github.com/attaswift/BigInt",
+        "state": {
+          "branch": null,
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
+        }
+      },
+      {
         "package": "CryptoSwift",
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
           "revision": "4b0565384d3c4c588af09e660535b2c7c9bf5b39",
           "version": "1.4.2"
+        }
+      },
+      {
+        "package": "GenericJSON",
+        "repositoryURL": "https://github.com/zoul/generic-json-swift",
+        "state": {
+          "branch": null,
+          "revision": "a137894b2a217abe489cdf1ea287e6f7819b1051",
+          "version": "2.0.1"
         }
       },
       {
@@ -20,12 +38,12 @@
         }
       },
       {
-        "package": "secp256k1",
-        "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
+        "package": "web3.swift",
+        "repositoryURL": "https://github.com/tvongerlach/web3.swift",
         "state": {
           "branch": null,
-          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
-          "version": "0.1.4"
+          "revision": "8205d3f671e0248af7d2e0537664d1a85d1ee11e",
+          "version": "0.8.1"
         }
       }
     ]


### PR DESCRIPTION
This PR 
- adds the Web3.swift package as a dependency (https://github.com/argentlabs/web3.swift)
- fetches an addresses balance on the transaction screen

In order for this to work you need to set your own values for `clientUrl` and `ethAccountAddress` in `TransactionsView`

Then you should see this:

![simulator_screenshot_84F66DBE-57F8-4B9F-9A4C-7AD7096DCF35](https://user-images.githubusercontent.com/18754377/137551096-03b99610-5acb-4600-bf44-13849a8a8bf0.png)
