### PR TITLE
Fix - RPC call for method with no parameters failed

### DIFF
--- a/Shared (App and Extension)/Providers/Provider.swift
+++ b/Shared (App and Extension)/Providers/Provider.swift
@@ -42,7 +42,7 @@ extension Provider {
      -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":0}'
      */
     func ethBlockNumber() async throws -> String {
-        return try await JsonRpcClient.makeRequest(url: baseURL, method: "eth_blockNumber", params: [""], resultType: String.self) // TODO: jsonRpcError(Wallet.JsonRpcError(code: -32602, message: "Invalid method parameter(s)."))
+        return try await JsonRpcClient.makeRequest(url: baseURL, method: "eth_blockNumber", resultType: String.self) // TODO: jsonRpcError(Wallet.JsonRpcError(code: -32602, message: "Invalid method parameter(s)."))
     }
     
     /*

--- a/Shared (App)/Networking/JsonRpcClient.swift
+++ b/Shared (App)/Networking/JsonRpcClient.swift
@@ -47,4 +47,12 @@ class JsonRpcClient {
       }
    }
    
+   static func makeRequest<R: Codable>(url: URL,
+                                       method: String,
+                                       resultType: R.Type,
+                                       urlSession: WalletURLSession = URLSession.shared)  async throws -> R {
+      let params: [Bool] = []
+      return try await JsonRpcClient.makeRequest(url: url, method: method, params: params, resultType: resultType)
+   }
+   
 }


### PR DESCRIPTION
This fixes the error `jsonRpcError(Wallet.JsonRpcError(code: -32602, message: "Invalid method parameter(s)."))`

To fix it, I created an overload method that doesn't have a `parameters` parameter that sets a default that satisfies RPC methods not expecting parameter values.

 